### PR TITLE
Change/async before request

### DIFF
--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -275,7 +275,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
       this.syncClientServerClock_(this.onClientServerClockSync_.bind(this));
     })
-      .then(xhr => this.request = xhr);
+      .then(request => this.request = request);
   }
 
   /**
@@ -335,7 +335,7 @@ export default class DashPlaylistLoader extends EventTarget {
 
       done();
     })
-      .then(xhr => this.request = xhr);
+      .then(request => this.request = request);
   }
 
   /**
@@ -414,7 +414,7 @@ export default class DashPlaylistLoader extends EventTarget {
         this.trigger('minimumUpdatePeriod');
       }, this.master.minimumUpdatePeriod);
     })
-      .then(xhr => this.request = xhr);
+      .then(request => this.request = request);
   }
 
   /**

--- a/src/dash-playlist-loader.js
+++ b/src/dash-playlist-loader.js
@@ -239,7 +239,7 @@ export default class DashPlaylistLoader extends EventTarget {
     this.started = true;
 
     // request the specified URL
-    this.request = this.hls_.xhr({
+    this.hls_.xhr({
       uri: this.srcUrl,
       withCredentials: this.withCredentials
     }, (error, req) => {
@@ -274,7 +274,8 @@ export default class DashPlaylistLoader extends EventTarget {
       }
 
       this.syncClientServerClock_(this.onClientServerClockSync_.bind(this));
-    });
+    })
+      .then(xhr => this.request = xhr);
   }
 
   /**
@@ -299,7 +300,7 @@ export default class DashPlaylistLoader extends EventTarget {
       return done();
     }
 
-    this.request = this.hls_.xhr({
+    this.hls_.xhr({
       uri: resolveUrl(this.srcUrl, utcTiming.value),
       method: utcTiming.method,
       withCredentials: this.withCredentials
@@ -333,7 +334,8 @@ export default class DashPlaylistLoader extends EventTarget {
       this.clientOffset_ = serverTime - Date.now();
 
       done();
-    });
+    })
+      .then(xhr => this.request = xhr);
   }
 
   /**
@@ -376,7 +378,7 @@ export default class DashPlaylistLoader extends EventTarget {
    * TODO: Does the client offset need to be recalculated when the xml is refreshed?
    */
   refreshXml_() {
-    this.request = this.hls_.xhr({
+    this.hls_.xhr({
       uri: this.srcUrl,
       withCredentials: this.withCredentials
     }, (error, req) => {
@@ -411,7 +413,8 @@ export default class DashPlaylistLoader extends EventTarget {
       window.setTimeout(() => {
         this.trigger('minimumUpdatePeriod');
       }, this.master.minimumUpdatePeriod);
-    });
+    })
+      .then(xhr => this.request = xhr);
   }
 
   /**

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -47,8 +47,8 @@ const segmentXhrHeaders = function(segment) {
  * @param {Object} activeXhrs - an object that tracks all XHR requests
  */
 const abortAll = (activeXhrs) => {
-  activeXhrs.forEach((xhr) => {
-    xhr.abort();
+  activeXhrs.forEach(promise => {
+    promise.then(xhr => xhr.abort());
   });
 };
 
@@ -469,7 +469,7 @@ export const mediaSegmentRequest = (xhr,
                                                        finishProcessingFn);
   const segmentXhr = xhr(segmentRequestOptions, segmentRequestCallback);
 
-  segmentXhr.addEventListener('progress', handleProgress(segment, progressFn));
+  segmentXhr.then(s => s.addEventListener('progress', handleProgress(segment, progressFn)));
   activeXhrs.push(segmentXhr);
 
   return () => abortAll(activeXhrs);

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -48,7 +48,7 @@ const segmentXhrHeaders = function(segment) {
  */
 const abortAll = (activeXhrs) => {
   activeXhrs.forEach(promise => {
-    promise.then(xhr => xhr.abort());
+    promise.then(request => request.abort());
   });
 };
 
@@ -469,7 +469,7 @@ export const mediaSegmentRequest = (xhr,
                                                        finishProcessingFn);
   const segmentXhr = xhr(segmentRequestOptions, segmentRequestCallback);
 
-  segmentXhr.then(s => s.addEventListener('progress', handleProgress(segment, progressFn)));
+  segmentXhr.then(request => request.addEventListener('progress', handleProgress(segment, progressFn)));
   activeXhrs.push(segmentXhr);
 
   return () => abortAll(activeXhrs);

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -223,7 +223,7 @@ export default class PlaylistLoader extends EventTarget {
 
       this.state = 'HAVE_CURRENT_METADATA';
 
-      this.request = this.hls_.xhr({
+      this.hls_.xhr({
         uri: resolveUrl(this.master.uri, this.media().uri),
         withCredentials: this.withCredentials
       }, (error, req) => {
@@ -238,7 +238,8 @@ export default class PlaylistLoader extends EventTarget {
         }
 
         this.haveMetadata(this.request, this.media().uri);
-      });
+      })
+        .then(xhr => this.request = xhr);
     });
   }
 
@@ -400,7 +401,7 @@ export default class PlaylistLoader extends EventTarget {
       this.trigger('mediachanging');
     }
 
-    this.request = this.hls_.xhr({
+    this.hls_.xhr({
       uri: resolveUrl(this.master.uri, playlist.uri),
       withCredentials: this.withCredentials
     }, (error, req) => {
@@ -421,7 +422,8 @@ export default class PlaylistLoader extends EventTarget {
       } else {
         this.trigger('mediachange');
       }
-    });
+    })
+      .then(xhr => this.request = xhr);
   }
 
   /**
@@ -484,7 +486,7 @@ export default class PlaylistLoader extends EventTarget {
     this.started = true;
 
     // request the specified URL
-    this.request = this.hls_.xhr({
+    this.hls_.xhr({
       uri: this.srcUrl,
       withCredentials: this.withCredentials
     }, (error, req) => {
@@ -560,6 +562,7 @@ export default class PlaylistLoader extends EventTarget {
       this.master.playlists[0].attributes = this.master.playlists[0].attributes || {};
       this.haveMetadata(req, this.srcUrl);
       return this.trigger('loadedmetadata');
-    });
+    })
+      .then(xhr => this.request = xhr);
   }
 }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -239,7 +239,7 @@ export default class PlaylistLoader extends EventTarget {
 
         this.haveMetadata(this.request, this.media().uri);
       })
-        .then(xhr => this.request = xhr);
+        .then(request => this.request = request);
     });
   }
 
@@ -423,7 +423,7 @@ export default class PlaylistLoader extends EventTarget {
         this.trigger('mediachange');
       }
     })
-      .then(xhr => this.request = xhr);
+      .then(request => this.request = request);
   }
 
   /**
@@ -563,6 +563,6 @@ export default class PlaylistLoader extends EventTarget {
       this.haveMetadata(req, this.srcUrl);
       return this.trigger('loadedmetadata');
     })
-      .then(xhr => this.request = xhr);
+      .then(request => this.request = request);
   }
 }


### PR DESCRIPTION
## Description
The implementation of `hls.xhr.beforeRequest` slightly modified so it can be used as an asynchronous function.

## Specific Changes proposed
The return value of `hls.xhr.beforeRequest` can either be a Promise or an Object literal, but it is always resolved as a Promise with `Promise.resolve()` and then handled accordingly. This affects Xhr requests, which are now Promises, therefore resolved as such before any of their methods or properties being used inside the project.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://jsbin.com/gejugat/edit?html,output))
- [ ] Reviewed by Two Core Contributors
